### PR TITLE
updated Star Wars API endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ const resolvers = {
   Query: {
     hello: (_, { name }) => `Hello ${name || "World"}`,
     getPerson: async (_, { id }) => {
-      const response = await fetch(`https://swapi.co/api/people/${id}/`);
+      const response = await fetch(`https://swapi.dev/api/people/${id}/`);
       return response.json();
     }
   }


### PR DESCRIPTION
The swapi.co endpoint was retired not too long ago. I updated the API reference to the new swapi.dev endpoint. Everything else remains the same and works like a charm with the proper endpoint in place.